### PR TITLE
Create .env file when running specs in generated gem

### DIFF
--- a/lib/huginn_agent/spec_runner.rb
+++ b/lib/huginn_agent/spec_runner.rb
@@ -34,6 +34,9 @@ class HuginnAgent
         shell_out "cp .env spec/huginn"
       end
       Dir.chdir('spec/huginn') do
+        if !File.exists?('.env')
+          shell_out "cp .env.example .env"
+        end
         shell_out "bundle install --without development production -j 4", 'Installing ruby gems ...'
       end
 


### PR DESCRIPTION
@dsander Hey! :smile:

This fixed the following issue for me when scaffolding a new gem.

```
~/projects/hackathons/xdhax/huginn_xero_agent (master)$ rake
Cloning huginn source ... [OK]
Resetting Huginn source ... [OK]
Installing ruby gems ... [FAIL]
Tried executing 'bundle install --without development production -j 4'
The latest bundler is 1.16.0.pre.2, but you are currently running 1.15.4.
To update, run `gem install bundler --pre`
Could not load huginn settings from .env file.

Make sure to copy the .env.example to .env and change it to match your configuration.

Capistrano 2 users: Make sure shared files are symlinked before bundle runs: before 'bundle:install', 'deploy:symlink_configs'

[!] There was an error parsing `Gemfile`: Could not load huginn settings from .env file.. Bundler cannot continue.

 #  from /Users/andrew/projects/hackathons/xdhax/huginn_xero_agent/spec/huginn/Gemfile:14
 #  -------------------------------------------
 #  require File.join(File.dirname(__FILE__), 'lib/gemfile_helper.rb')
 >  GemfileHelper.load_dotenv do |dotenv_dir|
 #    path dotenv_dir do
 #  -------------------------------------------
rake aborted!
```