### PR TITLE
split require! code, adds additional_agents() method

### DIFF
--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -26,9 +26,13 @@ class HuginnAgent
       load_paths.each do |path|
         require path
       end
-      agent_paths.each do |path|
+      Agent::TYPES << additional_agents
+    end
+
+    def additional_agents
+      @additional_agents ||= agent_paths.map do |path|
         require path
-        Agent::TYPES << "Agents::#{File.basename(path.to_s).camelize}"
+        "Agents::#{File.basename(path.to_s).camelize}"
       end
     end
 


### PR DESCRIPTION
This PR adds an `additional_agents` helper method that is then used in the `require!`.

The change does not add/modify any functionality but will make the [patch to fix this issue in Huginn](https://github.com/huginn/huginn/issues/2845) much much cleaner.