### PR TITLE
Fix Zeitwerk eager loading and GemfileHelper conflicts

### DIFF
--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -27,7 +27,7 @@ class HuginnAgent
         require path
       end
       agent_paths.each do |path|
-        setup_zeitwerk_loader path
+        require path
         Agent::TYPES << "Agents::#{File.basename(path.to_s).camelize}"
       end
     end
@@ -40,18 +40,6 @@ class HuginnAgent
 
     def agent_paths
       @agent_paths ||= []
-    end
-
-    def setup_zeitwerk_loader(gem_path)
-      gem, _, mod_path = gem_path.partition('/')
-      gemspec = Gem::Specification.find_by_name(gem)
-      gem_dir = Pathname.new(gemspec.gem_dir)
-      module_dir = gem_dir + gemspec.require_paths[0] + gem
-
-      loader = Zeitwerk::Loader.new
-      loader.tag = gem
-      loader.push_dir(module_dir, namespace: Agents)
-      loader.setup
     end
   end
 end

--- a/lib/huginn_agent/patches/gemfile_helper.rb
+++ b/lib/huginn_agent/patches/gemfile_helper.rb
@@ -7,12 +7,9 @@ class GemfileHelper
     gemspec = Dir["#{base_path}/*.gemspec"].first
     previous_gems = Hash[dependencies.map { |dep| [dep.name, dep] }]
     Gem::Specification.load(gemspec).development_dependencies.each do |args|
-      previous_gem = previous_gems[args.name]
-      if previous_gem
-        abort "Gem #{args.to_s} in #{gemspec} conflicts with huginn/Gemfile" unless previous_gem.match?(args.to_spec)
-      else
-        yield args.name, *args.requirements_list
-      end
+      next if previous_gems.key?(args.name)
+
+      yield args.name, *args.requirements_list
     end
   end
 end

--- a/spec/lib/huginn_agent/patches/gemfile_helper_spec.rb
+++ b/spec/lib/huginn_agent/patches/gemfile_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'rubygems/dependency'
+
+describe 'gemfile_helper patch' do
+  let(:patch_path) { File.expand_path('../../../../lib/huginn_agent/patches/gemfile_helper.rb', __dir__) }
+  let(:rspec_dependency) { Gem::Dependency.new('rspec', '>= 0') }
+  let(:thor_dependency) { Gem::Dependency.new('thor', '~> 1.5') }
+  let(:gemspec) { instance_double(Gem::Specification, development_dependencies: [rspec_dependency, thor_dependency]) }
+
+  let(:context) do
+    Object.new.tap do |object|
+      object.instance_variable_set(:@dependencies, [Gem::Dependency.new('rspec', '~> 3.13')])
+      object.instance_variable_set(:@added_gems, [])
+
+      object.define_singleton_method(:dependencies) { @dependencies }
+      object.define_singleton_method(:gem) { |*args| @added_gems << args }
+      object.define_singleton_method(:added_gems) { @added_gems }
+    end
+  end
+
+  before do
+    allow(Gem::Specification).to receive(:load).and_return(gemspec)
+  end
+
+  it 'does not add development dependencies already present in Huginn' do
+    context.instance_eval(File.read(patch_path), patch_path)
+
+    expect(context.added_gems).to eq([['thor']])
+  end
+end

--- a/spec/lib/huginn_agent_spec.rb
+++ b/spec/lib/huginn_agent_spec.rb
@@ -37,12 +37,12 @@ describe HuginnAgent do
       HuginnAgent.require!
     end
 
-    it 'sets up Zeitwerk loader for registered paths and adds the class name to Agent::TYPES' do
+    it 'requires registered paths and adds the class name to Agent::TYPES' do
       class Agent; TYPES = []; end
       string_double = double('test_agent.rb', camelize: 'TestAgent')
       expect(File).to receive(:basename).and_return(string_double)
       HuginnAgent.register('/tmp/test_agent.rb')
-      expect(HuginnAgent).to receive(:setup_zeitwerk_loader).with('/tmp/test_agent.rb')
+      expect(HuginnAgent).to receive(:require).with('/tmp/test_agent.rb')
       HuginnAgent.require!
       expect(Agent::TYPES).to eq(['Agents::TestAgent'])
     end


### PR DESCRIPTION
- **Skip duplicate gems in GemfileHelper** — Instead of aborting on gem version conflicts between the agent gemspec and huginn's Gemfile, silently skip gems that are already present.  This avoids unnecessary failures when versions are compatible.
- **Require registered agent files directly** — Replace `setup_zeitwerk_loader` with plain `require`.  The Zeitwerk loader mapped the entire `lib/<gem_name>/` directory to the `Agents` namespace, which caused `version.rb` to be eagerly loaded as `Agents::Version` and fail with `NameError` in CI (`eager_load = true`).